### PR TITLE
Add CLI argparsing using `clap`. Also remove memory limits for slicing level 6+ PNGs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,10 +93,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "crc32fast"
@@ -168,6 +262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "image"
 version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,12 +374,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -330,6 +448,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "2.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,14 +479,93 @@ dependencies = [
 name = "tile-split"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "image",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "zune-inflate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 image = "^0.24.7"
+clap = { version = "^4", features = ["env", "derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,6 @@ pub struct Config<'a> {
     pub filename: &'a str, // $1
     pub tilesize: u32, // 256
     pub zoomlevel: u8, // eg 0 - 5
-    pub format: String, // png
+    pub tileformat: &'a str, // png
     pub folder: &'a str, // $OUTDIR out
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -8,7 +8,10 @@ pub struct TileImage<'c> {
 
 impl<'c> TileImage<'c> {
     pub fn create_img(&self) -> Result<DynamicImage, Error> {
-        Ok(ImageReader::open(&self.config.filename)?.decode()?)
+        let mut reader = ImageReader::open(&self.config.filename)?;
+        // Default memory limit of 512MB is too small for level 6+ PNGs
+        reader.no_limits();
+        Ok(reader.decode()?)
     }
 
     pub fn iter<'d>(&self, img: &'d DynamicImage) -> TilesIterator<'d> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,43 @@
-use std::env;
+use clap::Parser;
 use tile_split::{Config, TileImage};
 
-fn main() {
-    // Exit with an error if there is no filename arg
-    let filename: String = match env::args().nth(1) {
-        Some(arg) => arg.to_string(),
-        None => {
-            eprintln!("Error: Please provide a filename.");
-            std::process::exit(1);
-        }
-    };
-    let folder: String = env::var("OUTDIR").unwrap_or("out".to_string());
-    let format: String = env::var("FMT").unwrap_or("png".to_string());
-    let zoomlevel: u8 = env::var("ZOOMLEVEL").map(|s| s.parse::<u8>()).unwrap_or(Ok(5)).unwrap_or(5);
+/// Split input image files into sets of tiles.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Input PNG filename.
+    filename: String, 
 
-    let config: Config = Config {
-        filename: &filename,
-        folder: &folder,
-        format,
-        tilesize: 256,
-        zoomlevel,
+    /// Zoomlevel of input PNG file
+    #[arg(short='l', long, env)]
+    zoomlevel: u8,
+
+    /// Zoomrange to slice tiles for, currently unused.
+    #[arg(short='r', long, required(false), num_args=1.., value_delimiter = ' ')]
+    zoomrange: Vec<u8>,
+
+    /// Location to write output tiles to.
+    #[arg(short, long, env, required(false), default_value("out"))]
+    output_dir: String,
+
+    /// Dimension of output tiles, in pixels.
+    #[arg(short='s', long, required(false), default_value("256"))]
+    tilesize: u32,
+
+    /// Type of output tiles, currently unused.
+    #[arg(short='f', long, env, required(false), default_value("png"))]
+    tileformat: String,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let config = Config {
+            tilesize: args.tilesize,
+            filename: &args.filename,
+            zoomlevel: args.zoomlevel,
+            folder: &args.output_dir,
+            tileformat: &args.tileformat,
     };
     
     // create output folder


### PR DESCRIPTION
`clap` lets us ingest arguments from the command line in a slightly-convoluted yet effective way. There's an `env` thing you can drop into the `arg` attributes in the struct that will take arguments from environment variables if they're not explicitly passed via command line. The `--help` command for this prints the following output:

```
Split input image files into sets of tiles.

Usage: tile-split [OPTIONS] --zoomlevel <ZOOMLEVEL> <FILENAME>

Arguments:
  <FILENAME>  Input PNG filename

Options:
  -l, --zoomlevel <ZOOMLEVEL>     Zoomlevel of input PNG file [env: ZOOMLEVEL=]
  -r, --zoomrange <ZOOMRANGE>...  Zoomrange to slice tiles for, currently unused
  -o, --output-dir <OUTPUT_DIR>   Location to write output tiles to [env: OUTPUT_DIR=] [default: out]
  -s, --tilesize <TILESIZE>       Dimension of output tiles, in pixels [default: 256]
  -f, --tileformat <TILEFORMAT>   Type of output tiles, currently unused [env: TILEFORMAT=] [default: png]
  -h, --help                      Print help
  -V, --version                   Print version
```

The usage is that we give the binary a PNG file as input, and we tell it what zoomlevel that PNG file is via the `--zoomlevel` arg.  Currently it will just slice the whole thing into tiles of `--tilesize` dimensions - if we want to do a different zoomlevel, we need to give it a different-sized PNG. Once Dinh's downsampling code lands, we can add some additional logic using the `--zoomrange` command to specify which zoomlevels we want tiles for, like so:

```
tile-split level-5.png --zoomlevel 5 --zoomrange 2 3 4 5
```

And this would generate tiles for zoomlevels 2, 3, 4 and 5 from the single level 5 PNG we give it. That's still speculative though, and the `--zoomrange` argument is currently unusued.

Oh, also I removed the memory limits on loading images as the `image` library default of 512MB is too small for PNGs bigger than zoomlevel 5.

[JIRA ticket](https://visual-meaning.atlassian.net/browse/SMP-1912)

P.S. I do not know what is going on with the commit history - I branched from `fix-loop` before Mia merged it. Hopefully if I squash-and-merge it won't matter too much.