### PR TITLE
Use dashes for the zxy separator in png filenames

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use image::{DynamicImage, SubImage, ImageResult};
 
 fn save_subimage(img: &SubImage<&DynamicImage>, x: u32, y: u32, z: u8, config: &Config) -> ImageResult<()> {
     img.to_image().save(format!(
-        "{p}/{z}_{x}_{y}.{fmt}",
+        "{p}/{z}-{x}-{y}.{fmt}",
         p=config.folder,
         z=z,
         x=x,


### PR DESCRIPTION
See [Rosi's Teams message](https://teams.microsoft.com/l/message/19:0035f77e2a1c408d9b2ca57e9089f035@thread.tacv2/1699882035642?tenantId=6ff32cfa-a64a-424b-a436-7926f9c71c97&groupId=cbf37718-5823-4acf-a816-c7c1527ae960&parentMessageId=1699633873392&teamName=Software%20Development&channelName=Technical&createdTime=1699882035642), our existing convention is to use dashes for the z-x-y separator in PNG filenames (so the output is `1-0-1.png` or similar), but our Rust code instead uses underscores (`1_0_1.png`). Replace underscores with dashes to match existing convention.