### PR TITLE
Use zoomlevel as default zoomrange if zoomrange not passed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,11 +58,18 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
+    let zomr = if args.zoomrange.len() == 0 {
+        vec![args.zoomlevel]
+    }
+    else {
+        args.zoomrange
+    };
+
     let config = Config {
             tilesize: args.tilesize,
             filename: &args.filename,
             zoomlevel: args.zoomlevel,
-            zoomrange: &args.zoomrange,
+            zoomrange: &zomr,
             folder: &args.output_dir,
             tileformat: &args.tileformat,
     };


### PR DESCRIPTION
The resize changes now result in a no-op if zoomlevel is passed but zoomrange is not passed, as `resize_range` does `self.config.zoomrange.iter()` to return resized images to pass on to `tile_image`. If `zoomrange` is empty, then nothing happens. We could always pass `--zoomlevel 5 --zoomrange 5` if we want to slice tiles for just a single zoomlevel, but this is annoying.

So, if zoomrange isn't passed, assume that we want to slice tiles for the input PNG's zoomlevel only (specified by `--zoomlevel`, which is a compulsory argument), and use `args.zoomlevel` as the default `zoomrange` if `zoomrange` itself is empty.