### PR TITLE
Fanicer things with arg types and Resizer as trait

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,11 @@
+use std::ops::RangeInclusive;
+use std::path::Path;
+
 pub struct Config<'a> {
-    pub filename: &'a str,      // $1
-    pub tilesize: u32,          // 256
-    pub zoomlevel: u8,          // eg 0 - 5
-    pub zoomrange: &'a Vec<u8>, // eg 0 - 5
-    pub tileformat: &'a str,    // png
-    pub folder: &'a str,        // $OUTDIR out
+    pub filename: &'a Path,            // $1
+    pub tilesize: u32,                 // 256
+    pub zoomlevel: u8,                 // eg 5
+    pub zoomrange: RangeInclusive<u8>, // eg 0 - 5
+    pub tileformat: &'a str,           // png
+    pub folder: &'a Path,              // $OUTDIR out
 }

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -2,56 +2,45 @@ use crate::Config;
 use image::imageops;
 use image::DynamicImage;
 
-pub type ResizedItem = (DynamicImage, u8);
+pub trait Resizer<'iter, T> {
+    type ItemIterator: Iterator<Item = (T, u8)>;
 
-pub struct Resizer<'c> {
-    pub config: &'c Config<'c>,
+    fn resize_range(&'iter self, img: &'iter T) -> Self::ItemIterator;
 }
 
-impl<'c> Resizer<'c> {
-    fn _check_dimension(&self, img: &'c DynamicImage) {
-        let (img_width, img_height) = (img.width(), img.height());
-        let max_dimension_size = self.config.tilesize << self.config.zoomlevel;
-        if img_width != max_dimension_size || img_height != max_dimension_size {
-            panic!(
-                "Image of size {w}x{h} cannot be split into
-                tiles of size {tile_size} and max zoom level {max_zoom}.",
-                w = img_width,
-                h = img_height,
-                tile_size = self.config.tilesize,
-                max_zoom = self.config.zoomlevel,
-            );
-        }
+type ResizedItem = (DynamicImage, u8);
+
+fn _check_dimension(config: &Config, img: &DynamicImage) {
+    if *config.zoomrange.end() > config.zoomlevel {
+        panic!("Zoom range has value(s) larger than zoom level.");
     }
-
-    fn _resize(img: &'c DynamicImage, width: u32, height: u32) -> DynamicImage {
-        img.resize(width, height, imageops::FilterType::Lanczos3)
+    let (img_width, img_height) = (img.width(), img.height());
+    let max_dimension_size = config.tilesize << config.zoomlevel;
+    if img_width != max_dimension_size || img_height != max_dimension_size {
+        panic!(
+            "Image of size {w}x{h} cannot be split into
+            tiles of size {tile_size} and max zoom level {max_zoom}.",
+            w = img_width,
+            h = img_height,
+            tile_size = config.tilesize,
+            max_zoom = config.zoomlevel,
+        );
     }
+}
 
-    pub fn new(config: &'c Config<'c>) -> Self {
-        let Config {
-            zoomlevel,
-            zoomrange,
-            ..
-        } = &config;
-        // Do we need zoomlevel?
-        if zoomrange.iter().any(|x| x > zoomlevel) {
-            panic!("Zoom range has value(s) larger than zoom level.");
-        }
+fn _resize(img: &DynamicImage, width: u32, height: u32) -> DynamicImage {
+    img.resize(width, height, imageops::FilterType::Lanczos3)
+}
 
-        Self { config }
-    }
+impl<'iter> Resizer<'iter, DynamicImage> for Config<'_> {
+    type ItemIterator = Box<dyn Iterator<Item = ResizedItem> + 'iter>;
 
-    pub fn resize_range(&self, img: &'c DynamicImage) -> Vec<ResizedItem> {
-        self._check_dimension(img);
+    fn resize_range(&'iter self, img: &'iter DynamicImage) -> Self::ItemIterator {
+        _check_dimension(self, img);
 
-        self.config
-            .zoomrange
-            .iter()
-            .map(|&x| {
-                let t_size = self.config.tilesize << x;
-                (Self::_resize(img, t_size, t_size), x)
-            })
-            .collect()
+        Box::new(self.zoomrange.clone().map(|x| {
+            let t_size = self.tilesize << x;
+            (_resize(img, t_size, t_size), x)
+        }))
     }
 }


### PR DESCRIPTION
Make path-like cli args parse into path types.

Make range-like cli arg parse into RangeInclusive, implemented with value_parser from clap.

Show one way of making Resizer not a new struct holding Config but instead a trait that can use Config.

Example of using Box to return an iterator.

Only write the resized images or the tiled images, not both.

@kisoso I hope this is informative - your choice to _not_ work out the iterator bit and return `Vec` was a good tactical one! Also with parallel iterators later, we'll want something slightly different anyway, but this is one bit of spelling that may be helpful to know. In general `Box` helps with a lot of issues!