### PR TITLE
Iterate tiles with z-order curve

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 pub struct Config<'a> {
     pub filename: &'a str,      // $1
-    pub tilesize: u16,          // 256
+    pub tilesize: u32,          // 256
     pub zoomlevel: u8,          // eg 0 - 5
     pub zoomrange: &'a Vec<u8>, // eg 0 - 5
     pub tileformat: &'a str,    // png

--- a/src/image.rs
+++ b/src/image.rs
@@ -19,8 +19,8 @@ impl<'c> TileImage<'c> {
         TilesIterator {
             img,
             morton_idx: 0,
-            morton_idx_max: (img.width() / self.config.tilesize as u32)
-                * (img.height() / self.config.tilesize as u32),
+            morton_idx_max: img.width() / self.config.tilesize * img.height()
+                / self.config.tilesize,
             tilesize: self.config.tilesize,
         }
     }
@@ -30,30 +30,23 @@ pub struct TilesIterator<'d> {
     img: &'d DynamicImage,
     morton_idx: u32,
     morton_idx_max: u32,
-    tilesize: u16,
+    tilesize: u32,
 }
 
 impl<'d> Iterator for TilesIterator<'d> {
-    type Item = (SubImage<&'d DynamicImage>, u16, u16);
+    type Item = (SubImage<&'d DynamicImage>, u32, u32);
     fn next(&mut self) -> Option<Self::Item> {
         // reaching the end of slicing, return None
         let coord = coord_of(self.morton_idx);
+        let x = coord.0 as u32;
+        let y = coord.1 as u32;
         if self.morton_idx == self.morton_idx_max {
             None
         } else {
-            let x1 = coord.0 * self.tilesize;
-            let y1 = coord.1 * self.tilesize;
+            let x1 = x * self.tilesize;
+            let y1 = y * self.tilesize;
             // slice image
-            let result = (
-                self.img.view(
-                    x1.into(),
-                    y1.into(),
-                    self.tilesize.into(),
-                    self.tilesize.into(),
-                ),
-                coord.0,
-                coord.1,
-            );
+            let result = (self.img.view(x1, y1, self.tilesize, self.tilesize), x, y);
             self.morton_idx += 1;
             Some(result)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use tile_split::{Config, Resizer, TileImage};
 
 fn save_subimage(
     img: &SubImage<&DynamicImage>,
-    x: u16,
-    y: u16,
+    x: u32,
+    y: u32,
     z: u8,
     config: &Config,
 ) -> ImageResult<()> {
@@ -49,7 +49,7 @@ struct Args {
 
     /// Dimension of output tiles, in pixels.
     #[arg(short = 's', long, required(false), default_value("256"))]
-    tilesize: u16,
+    tilesize: u32,
 
     /// Type of output tiles, currently unused.
     #[arg(short = 'f', long, env, required(false), default_value("png"))]

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -11,7 +11,7 @@ pub struct Resizer<'c> {
 impl<'c> Resizer<'c> {
     fn _check_dimension(&self, img: &'c DynamicImage) {
         let (img_width, img_height) = (img.width(), img.height());
-        let max_dimension_size = (self.config.tilesize << self.config.zoomlevel) as u32;
+        let max_dimension_size = self.config.tilesize << self.config.zoomlevel;
         if img_width != max_dimension_size || img_height != max_dimension_size {
             panic!(
                 "Image of size {w}x{h} cannot be split into
@@ -49,7 +49,7 @@ impl<'c> Resizer<'c> {
             .zoomrange
             .iter()
             .map(|&x| {
-                let t_size = (self.config.tilesize << x) as u32;
+                let t_size = self.config.tilesize << x;
                 (Self::_resize(img, t_size, t_size), x)
             })
             .collect()


### PR DESCRIPTION
Use `morton index` for tiles iteration and derive coords from `zorder` crate. This is the first pass to linear ordering approach that aims to distribute the slicing work equally across different zoom levels.