### PR TITLE
Fixed morton idx iteratio.

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -29,9 +29,14 @@ impl<'c> TileImage<'c> {
         let height_in_tiles = img.height() / self.config.tilesize;
         let morton_idx_max = width_in_tiles * height_in_tiles;
 
+        let morton_idx = match &self.config.targetrange {
+            Some(targetrange) => *targetrange.start(),
+            None => 0,
+        };
+
         TilesIterator {
             img,
-            morton_idx: 0,
+            morton_idx,
             morton_idx_max,
             tilesize: self.config.tilesize,
             targetrange: self.config.targetrange.clone(),


### PR DESCRIPTION
If --targetrange is starting from middle, e.g. 10-20, the first TilesIterator iteration will return None (`0` is not in `10..=20`) and not fall down to increase morton_idx.
Change the starting idx of TilesIterator.

[JIRA](https://visual-meaning.atlassian.net/browse/SMP-1923)