### PR TITLE
Improvement on dividing tiling work into equal chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,19 @@ The binary takes a single PNG file as an input, which must be a square. We tell 
 
     tile-split level-5.png --zoomlevel 5
 
-We can also optionally take a PNG for a high zoom level, downsize it to create PNGs of lower zoom levels, and then also slice those into tiles. The `--zoomrange` argument is used to specify which zoomlevels we want to generate tiles for. The `--targetrange` argument specifies subset of tiles to slice, if not provided the full range of tiles is sliced.
+We can also optionally take a PNG for a high zoom level, downsize it to create PNGs of lower zoom levels, and then also slice those into tiles. The `--zoomrange` argument is used to specify which zoomlevels we want to generate tiles for. 
 
-    tile-split level-5.png --zoomlevel 5 --zoomrange 2-5 --targetrange 0-44
+The `--totalfunction` specifies how many sections of work to divide to slice the tiles from zoomrange and the `--functionindex` arguments specifies the section of the tiles we will get. They are mostly used for aws to spread the tiles slicing work equally across mutiple lambda functions. The default value for both `--totalfunction` and `--functionindex` are 1, which means to slice all tiles requested.
 
-This would generate tiles for zoomlevels 2, 3, 4 and 5 from the single level 5 PNG and slice a subset of 45 tiles for each level.
+    tile-split level-5.png --zoomlevel 5 --zoomrange 2-5 --functionindex 1 --totalfunction 4
+
+This would resize the input single level 5 PNG for zoomlevels 2, 3, 4 5 pngs and slice all tiles from level 2, 3, 4 and first 3 tiles from level 5.
+
+```
+tile-split level-5.png --zoomlevel 5 --zoomrange 2-5 --functionindex 2 --totalfunction 4
+```
+
+This would resize the input single level 5 PNG for zoomlevels 5 png only and slice tiles 4 - 343 from level 5. 
 
 Note that we cannot upscale an input PNG to higher zoomlevels, only downscale -- so all zoomlevels passed via `--zoomrange` must be equal to or less than the input PNG zoomlevel passed via `--zoomlevel`.
 
@@ -43,11 +51,12 @@ Arguments:
 Options:
   -l, --zoomlevel <ZOOMLEVEL>     Zoomlevel of input PNG file [env: ZOOMLEVEL=]
   -r, --zoomrange <ZOOMRANGE>...  Zoomrange to slice tiles for
-  -t, --targetrange               Targetrange to slice subset of tiles. Optional.
   -o, --output-dir <OUTPUT_DIR>   Location to write output tiles to [env: OUTPUT_DIR=] [default: out]
   -s, --tilesize <TILESIZE>       Dimension of output tiles, in pixels [default: 256]
   -f, --tileformat <TILEFORMAT>   Type of output tiles, currently unused [env: TILEFORMAT=] [default: png]
       --save-resize               Save the resized files [env: SAVE_RESIZE=]
+      --functionindex <FUNCTIONINDEX>  Index of the function in functions range. Value should start from 1 and no more than totalfunction [default: 1]
+      --totalfunction <TOTALFUNCTION>  Number of functions in total [default: 1]
   -h, --help                      Print help
   -V, --version                   Print version
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Arguments:
 Options:
   -l, --zoomlevel <ZOOMLEVEL>     Zoomlevel of input PNG file [env: ZOOMLEVEL=]
   -r, --zoomrange <ZOOMRANGE>...  Zoomrange to slice tiles for
-  -t, --targetrange Targetrange to slice subset of tiles. Optional.
+  -t, --targetrange               Targetrange to slice subset of tiles. Optional.
   -o, --output-dir <OUTPUT_DIR>   Location to write output tiles to [env: OUTPUT_DIR=] [default: out]
   -s, --tilesize <TILESIZE>       Dimension of output tiles, in pixels [default: 256]
   -f, --tileformat <TILEFORMAT>   Type of output tiles, currently unused [env: TILEFORMAT=] [default: png]

--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@ The binary takes a single PNG file as an input, which must be a square. We tell 
 
     tile-split level-5.png --zoomlevel 5
 
-We can also optionally take a PNG for a high zoom level, downsize it to create PNGs of lower zoom levels, and then also slice those into tiles. The `--zoomrange` argument is used to specify which zoomlevels we want to generate tiles for. 
+We can also optionally take a PNG for a high zoom level, downsize it to create PNGs of lower zoom levels, and then also slice those into tiles. The `--zoomrange` argument is used to specify which zoomlevels we want to generate tiles for. The `--targetrange` argument specifies subset of tiles to slice, if not provided the full range of tiles is sliced.
 
-The `--totalfunction` specifies how many sections of work to divide to slice the tiles from zoomrange and the `--functionindex` arguments specifies the section of the tiles we will get. They are mostly used for aws to spread the tiles slicing work equally across mutiple lambda functions. The default value for both `--totalfunction` and `--functionindex` are 1, which means to slice all tiles requested.
+    tile-split level-5.png --zoomlevel 5 --zoomrange 2-5 --targetrange 0-44
 
-    tile-split level-5.png --zoomlevel 5 --zoomrange 2-5 --functionindex 1 --totalfunction 4
+This would generate tiles for zoomlevels 2, 3, 4 and 5 from the single level 5 PNG and slice the first subset of 45 tiles for the whole zoom range.
 
-This would resize the input single level 5 PNG for zoomlevels 2, 3, 4 5 pngs and slice all tiles from level 2, 3, 4 and first 3 tiles from level 5.
+For example, for a chunk size of 300 tiles per round, the arguments would be
 
-```
-tile-split level-5.png --zoomlevel 5 --zoomrange 2-5 --functionindex 2 --totalfunction 4
-```
-
-This would resize the input single level 5 PNG for zoomlevels 5 png only and slice tiles 4 - 343 from level 5. 
+    tile-split level-5.png --zoomlevel 5 --zoomrange 0-5 --targetrange 0-300
+    tile-split level-5.png --zoomlevel 5 --zoomrange 0-5 --targetrange 300-600
+    tile-split level-5.png --zoomlevel 5 --zoomrange 0-5 --targetrange 600-900
+    tile-split level-5.png --zoomlevel 5 --zoomrange 0-5 --targetrange 900-1200
+    tile-split level-5.png --zoomlevel 5 --zoomrange 0-5 --targetrange 1200-1365
 
 Note that we cannot upscale an input PNG to higher zoomlevels, only downscale -- so all zoomlevels passed via `--zoomrange` must be equal to or less than the input PNG zoomlevel passed via `--zoomlevel`.
 
@@ -51,12 +51,11 @@ Arguments:
 Options:
   -l, --zoomlevel <ZOOMLEVEL>     Zoomlevel of input PNG file [env: ZOOMLEVEL=]
   -r, --zoomrange <ZOOMRANGE>...  Zoomrange to slice tiles for
+  -t, --targetrange Targetrange to slice subset of tiles. Optional.
   -o, --output-dir <OUTPUT_DIR>   Location to write output tiles to [env: OUTPUT_DIR=] [default: out]
   -s, --tilesize <TILESIZE>       Dimension of output tiles, in pixels [default: 256]
   -f, --tileformat <TILEFORMAT>   Type of output tiles, currently unused [env: TILEFORMAT=] [default: png]
       --save-resize               Save the resized files [env: SAVE_RESIZE=]
-      --functionindex <FUNCTIONINDEX>  Index of the function in functions range. Value should start from 1 and no more than totalfunction [default: 1]
-      --totalfunction <TOTALFUNCTION>  Number of functions in total [default: 1]
   -h, --help                      Print help
   -V, --version                   Print version
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,13 +2,13 @@ use std::ops::RangeInclusive;
 use std::path::Path;
 
 pub struct Config<'a> {
-    pub filename: &'a Path,                       // $1
-    pub tilesize: u32,                            // 256
-    pub zoomlevel: u8,                            // eg 5
-    pub zoomrange: RangeInclusive<u8>,            // eg 0 - 5
-    pub tileformat: &'a str,                      // png
-    pub folder: &'a Path,                         // $OUTDIR out
-    pub functionindex: u32,                        // eg 2
-    pub totalfunction: u32,                        // eg 4
-    pub zoomrangetoslice: RangeInclusive<u8>,     // eg 0 - 5
+    pub filename: &'a Path,                   // $1
+    pub tilesize: u32,                        // 256
+    pub zoomlevel: u8,                        // eg 5
+    pub zoomrange: RangeInclusive<u8>,        // eg 0 - 5
+    pub tileformat: &'a str,                  // png
+    pub folder: &'a Path,                     // $OUTDIR out
+    pub functionindex: u32,                   // eg 2
+    pub totalfunction: u32,                   // eg 4
+    pub zoomrangetoslice: RangeInclusive<u8>, // eg 0 - 5
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,13 +2,89 @@ use std::ops::RangeInclusive;
 use std::path::Path;
 
 pub struct Config<'a> {
-    pub filename: &'a Path,                   // $1
-    pub tilesize: u32,                        // 256
-    pub zoomlevel: u8,                        // eg 5
-    pub zoomrange: RangeInclusive<u8>,        // eg 0 - 5
-    pub tileformat: &'a str,                  // png
-    pub folder: &'a Path,                     // $OUTDIR out
-    pub functionindex: u32,                   // eg 2
-    pub totalfunction: u32,                   // eg 4
-    pub zoomrangetoslice: RangeInclusive<u8>, // eg 0 - 5
+    pub filename: &'a Path, // $1
+    pub tilesize: u32,      // 256
+    pub zoomlevel: u8,      // eg 5
+    pub startzoomrangetoslice: u8,
+    pub endzoomrangetoslice: u8,
+    pub starttargetrange: u32,
+    pub endtargetrange: u32,
+}
+
+impl<'a> Config<'a> {
+    pub fn new(
+        filename: &'a Path,            // $1
+        tilesize: u32,                 // 256
+        zoomlevel: u8,                 // eg 5
+        zoomrange: RangeInclusive<u8>, // eg 0 - 5
+        functionindex: u32,            // eg 2
+        totalfunction: u32,            // eg 4
+    ) -> Self {
+        let zomr = if zoomrange.is_empty() {
+            zoomlevel..=zoomlevel
+        } else {
+            zoomrange
+        };
+        // total number of tiles required in zoomrange
+        let mut totaltiles = 0;
+        zomr.clone().for_each(|x| {
+            totaltiles += 1 << (x * 2);
+        });
+        let average = totaltiles / totalfunction;
+        // number of tiles sliced by previous functions
+        let tilessliced = average * (functionindex - 1);
+        // number of tiles to slice in this function, if it's the last
+        // function, it should slice all the remaining tiles
+        let mut tilestoslice = average;
+        if functionindex == totalfunction {
+            tilestoslice = totaltiles - tilessliced;
+        }
+
+        // zoom level to start
+        let mut startzoomrangetoslice: u8 = *zomr.clone().start();
+        // tile index to start
+        let mut starttargetrange: u32 = 0;
+        // zoom level to stop
+        let mut endzoomrangetoslice: u8 = *zomr.clone().end();
+        // tile index to stop
+        let mut endtargetrange: u32 = 0;
+
+        // total of tiles in previous zoom levels
+        let mut tilessum = 0;
+        // calculte startzoomrangetoslice and starttargetrange
+        for i in zomr.clone() {
+            // number of tiles in this zoom level
+            let currentzoomtiles = 1 << (i * 2);
+            if tilessum + currentzoomtiles > tilessliced {
+                startzoomrangetoslice = i;
+                starttargetrange = tilessliced - tilessum;
+                break;
+            } else {
+                tilessum += currentzoomtiles;
+            }
+        }
+        tilessum = 0;
+        // calculte endzoomrangetoslice and endtargetrange
+        for i in zomr.clone() {
+            // number of tiles in this zoom level
+            let currentzoomtiles = 1 << (i * 2);
+            if tilessum + currentzoomtiles >= tilessliced + tilestoslice {
+                endzoomrangetoslice = i;
+                endtargetrange = tilessliced + tilestoslice - tilessum - 1;
+                break;
+            } else {
+                tilessum += currentzoomtiles;
+            }
+        }
+
+        Config {
+            tilesize,
+            filename,
+            zoomlevel,
+            startzoomrangetoslice,
+            endzoomrangetoslice,
+            starttargetrange,
+            endtargetrange,
+        }
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,7 +95,7 @@ mod tests {
     use std::{ops::RangeInclusive, path::Path};
 
     #[test]
-    // one function in total
+    // slice all tiles
     fn full_zoom() {
         let config = Config::new(
             &Path::new("test.png"),
@@ -111,7 +111,7 @@ mod tests {
     }
 
     #[test]
-    // the first function out of 4 functions
+    // slice the first 341 tiles out of all tiles
     fn full_zoom_1() {
         let config = Config::new(
             &Path::new("test.png"),
@@ -127,7 +127,7 @@ mod tests {
     }
 
     #[test]
-    // the second function out of 4 functions
+    // slice the second 341 tiles out of all tiles
     fn full_zoom_2() {
         let config = Config::new(
             &Path::new("test.png"),
@@ -143,7 +143,7 @@ mod tests {
     }
 
     #[test]
-    // the third function out of 4 functions
+    // slice the third 341 tiles out of all tiles
     fn full_zoom_3() {
         let config = Config::new(
             &Path::new("test.png"),
@@ -159,7 +159,7 @@ mod tests {
     }
 
     #[test]
-    // the fourth function out of 4 functions
+    // slice the remaining tiles out of all tiles
     fn full_zoom_4() {
         let config = Config::new(
             &Path::new("test.png"),
@@ -175,7 +175,7 @@ mod tests {
     }
 
     #[test]
-    // the first function out of 3 functions
+    // slice the first 448 tiles out of all tiles
     fn half_zoom_1() {
         let config = Config::new(
             &Path::new("test.png"),
@@ -191,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    // the second function out of 3 functions
+    // slice the second 448 tiles out of all tiles
     fn half_zoom_2() {
         let config = Config::new(
             &Path::new("test.png"),
@@ -207,7 +207,7 @@ mod tests {
     }
 
     #[test]
-    // the third function out of 3 functions
+    // slice the remaining tiles out of all tiles
     fn half_zoom_3() {
         let config = Config::new(
             &Path::new("test.png"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,9 @@ impl<'a> Config<'a> {
             Some(targetrange) => *targetrange.end() - tilessliced,
             None => totaltiles,
         };
+        if tilestoslice > totaltiles {
+            panic!("Target range value cannot be over than the total number of tiles within zoom range.");
+        }
 
         // zoom level to start
         let mut startzoomrangetoslice: u8 = *zomr.clone().start();

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,9 @@ pub struct Config<'a> {
     pub tilesize: u32,                            // 256
     pub zoomlevel: u8,                            // eg 5
     pub zoomrange: RangeInclusive<u8>,            // eg 0 - 5
-    pub targetrange: Option<RangeInclusive<u32>>, //eg 0 - 500
     pub tileformat: &'a str,                      // png
     pub folder: &'a Path,                         // $OUTDIR out
+    pub functionindex: u32,                        // eg 2
+    pub totalfunction: u32,                        // eg 4
+    pub zoomrangetoslice: RangeInclusive<u8>,     // eg 0 - 5
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,3 +88,145 @@ impl<'a> Config<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Config;
+    use std::{ops::RangeInclusive, path::Path};
+
+    #[test]
+    // one function in total
+    fn full_zoom() {
+        let config = Config::new(
+            &Path::new("test.png"),
+            256,
+            5,
+            RangeInclusive::new(0, 5),
+            1,
+            1,
+        );
+        assert_eq!(config.startzoomrangetoslice, 0);
+        assert_eq!(config.starttargetrange, 0);
+        assert_eq!(config.endzoomrangetoslice, 5);
+        assert_eq!(config.endtargetrange, 1023);
+    }
+
+    #[test]
+    // the first function out of 4 functions
+    fn full_zoom_1() {
+        let config = Config::new(
+            &Path::new("test.png"),
+            256,
+            5,
+            RangeInclusive::new(0, 5),
+            1,
+            4,
+        );
+        assert_eq!(config.startzoomrangetoslice, 0);
+        assert_eq!(config.starttargetrange, 0);
+        assert_eq!(config.endzoomrangetoslice, 4);
+        assert_eq!(config.endtargetrange, 255);
+    }
+
+    #[test]
+    // the second function out of 4 functions
+    fn full_zoom_2() {
+        let config = Config::new(
+            &Path::new("test.png"),
+            256,
+            5,
+            RangeInclusive::new(0, 5),
+            2,
+            4,
+        );
+        assert_eq!(config.startzoomrangetoslice, 5);
+        assert_eq!(config.starttargetrange, 0);
+        assert_eq!(config.endzoomrangetoslice, 5);
+        assert_eq!(config.endtargetrange, 340);
+    }
+
+    #[test]
+    // the third function out of 4 functions
+    fn full_zoom_3() {
+        let config = Config::new(
+            &Path::new("test.png"),
+            256,
+            5,
+            RangeInclusive::new(0, 5),
+            3,
+            4,
+        );
+        assert_eq!(config.startzoomrangetoslice, 5);
+        assert_eq!(config.starttargetrange, 341);
+        assert_eq!(config.endzoomrangetoslice, 5);
+        assert_eq!(config.endtargetrange, 681);
+    }
+
+    #[test]
+    // the fourth function out of 4 functions
+    fn full_zoom_4() {
+        let config = Config::new(
+            &Path::new("test.png"),
+            256,
+            5,
+            RangeInclusive::new(0, 5),
+            4,
+            4,
+        );
+        assert_eq!(config.startzoomrangetoslice, 5);
+        assert_eq!(config.starttargetrange, 682);
+        assert_eq!(config.endzoomrangetoslice, 5);
+        assert_eq!(config.endtargetrange, 1023);
+    }
+
+    #[test]
+    // the first function out of 3 functions
+    fn half_zoom_1() {
+        let config = Config::new(
+            &Path::new("test.png"),
+            256,
+            5,
+            RangeInclusive::new(3, 5),
+            1,
+            3,
+        );
+        assert_eq!(config.startzoomrangetoslice, 3);
+        assert_eq!(config.starttargetrange, 0);
+        assert_eq!(config.endzoomrangetoslice, 5);
+        assert_eq!(config.endtargetrange, 127);
+    }
+
+    #[test]
+    // the second function out of 3 functions
+    fn half_zoom_2() {
+        let config = Config::new(
+            &Path::new("test.png"),
+            256,
+            5,
+            RangeInclusive::new(3, 5),
+            2,
+            3,
+        );
+        assert_eq!(config.startzoomrangetoslice, 5);
+        assert_eq!(config.starttargetrange, 128);
+        assert_eq!(config.endzoomrangetoslice, 5);
+        assert_eq!(config.endtargetrange, 575);
+    }
+
+    #[test]
+    // the third function out of 3 functions
+    fn half_zoom_3() {
+        let config = Config::new(
+            &Path::new("test.png"),
+            256,
+            5,
+            RangeInclusive::new(3, 5),
+            3,
+            3,
+        );
+        assert_eq!(config.startzoomrangetoslice, 5);
+        assert_eq!(config.starttargetrange, 576);
+        assert_eq!(config.endzoomrangetoslice, 5);
+        assert_eq!(config.endtargetrange, 1023);
+    }
+}

--- a/src/image.rs
+++ b/src/image.rs
@@ -24,12 +24,12 @@ impl<'c> TileImage<'c> {
         Ok(img)
     }
 
-    pub fn iter<'d>(&self, img: &'d DynamicImage) -> TilesIterator<'d> {
+    pub fn iter<'d>(&self, img: &'d DynamicImage, targetrangetoslice: Option<RangeInclusive<u32>>) -> TilesIterator<'d> {
         let width_in_tiles = img.width() / self.config.tilesize;
         let height_in_tiles = img.height() / self.config.tilesize;
         let morton_idx_max = width_in_tiles * height_in_tiles;
 
-        let morton_idx = match &self.config.targetrange {
+        let morton_idx = match &targetrangetoslice {
             Some(targetrange) => *targetrange.start(),
             None => 0,
         };
@@ -39,7 +39,7 @@ impl<'c> TileImage<'c> {
             morton_idx,
             morton_idx_max,
             tilesize: self.config.tilesize,
-            targetrange: self.config.targetrange.clone(),
+            targetrange: targetrangetoslice.clone(),
         }
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -24,7 +24,11 @@ impl<'c> TileImage<'c> {
         Ok(img)
     }
 
-    pub fn iter<'d>(&self, img: &'d DynamicImage, targetrangetoslice: Option<RangeInclusive<u32>>) -> TilesIterator<'d> {
+    pub fn iter<'d>(
+        &self,
+        img: &'d DynamicImage,
+        targetrangetoslice: Option<RangeInclusive<u32>>,
+    ) -> TilesIterator<'d> {
         let width_in_tiles = img.width() / self.config.tilesize;
         let height_in_tiles = img.height() / self.config.tilesize;
         let morton_idx_max = width_in_tiles * height_in_tiles;

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ struct Args {
     #[arg(long, env, action)]
     save_resize: bool,
 
-    /// Index of the function in functions range.
+    /// Index of the function in functions range. Value should start from 1 and no more than totalfunction.
     #[arg(long, required(false), default_value("1"))]
     functionindex: u32,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,17 +66,13 @@ struct Args {
     #[arg(long, env, required(false), default_value("png"))]
     tileformat: String,
 
+    /// Subset morton range of tiles to slice.
+    #[arg(short='t', long, required(false), value_parser = parse_range::<u32>)]
+    targetrange: Option<RangeInclusive<u32>>,
+
     /// Save the resized files
     #[arg(long, env, action)]
     save_resize: bool,
-
-    /// Index of the function in functions range. Value should start from 1 and no more than totalfunction.
-    #[arg(long, required(false), default_value("1"))]
-    functionindex: u32,
-
-    /// Number of functions in total.
-    #[arg(long, required(false), default_value("1"))]
-    totalfunction: u32,
 }
 
 fn main() {
@@ -92,8 +88,7 @@ fn main() {
         args.tilesize,
         args.zoomlevel,
         args.zoomrange,
-        args.functionindex,
-        args.totalfunction,
+        args.targetrange,
     );
 
     // instantiate TileImage

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,7 @@ fn main() {
             // the end zoom level should slice tiles from 0 to endtargetrange
             } else if z == startzoomrangetoslice {
                 if 1 << (z * 2) > 1 {
-                    targetrangetoslice = Some(starttargetrange..=1 << (z * 2) - 1);
+                    targetrangetoslice = Some(starttargetrange..=(1 << (z * 2)) - 1);
                 }               
             } else if z == endzoomrangetoslice {
                 targetrangetoslice = Some(0..=endtargetrange);

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn main() {
     });
     let average = totaltiles / args.totalfunction;
     // number of tiles sliced by previous functions
-    let tilessliced= average * (args.functionindex - 1);
+    let tilessliced = average * (args.functionindex - 1);
     // number of tiles to slice in this function, if it's the last
     // function, it should slice all the remaining tiles
     let mut tilestoslice = average;
@@ -116,9 +116,9 @@ fn main() {
     // tile index to start
     let mut starttargetrange: u32 = 0;
     // zoom level to stop
-    let mut endzoomrangetoslice: u8= *zomr.clone().end();
+    let mut endzoomrangetoslice: u8 = *zomr.clone().end();
     // tile index to stop
-    let mut endtargetrange: u32  = 0;
+    let mut endtargetrange: u32 = 0;
 
     // total of tiles in previous zoom levels
     let mut tilessum = 0;
@@ -133,7 +133,7 @@ fn main() {
         } else {
             tilessum += currentzoomtiles;
         }
-    };
+    }
     tilessum = 0;
     // calculte endzoomrangetoslice and endtargetrange
     for i in zomr.clone() {
@@ -146,7 +146,7 @@ fn main() {
         } else {
             tilessum += currentzoomtiles;
         }
-    };
+    }
 
     let config = Config {
         tilesize: args.tilesize,
@@ -173,7 +173,7 @@ fn main() {
         // save each sliced image
         resized_images.for_each(|(img, z)| {
             let mut targetrangetoslice: Option<RangeInclusive<u32>> = None;
-            // if startzoomrangetoslice is the same as endzoomrangetoslice, 
+            // if startzoomrangetoslice is the same as endzoomrangetoslice,
             // then tiles to be sliced in this function are from same zoom level
             if startzoomrangetoslice == endzoomrangetoslice {
                 if z == endzoomrangetoslice {
@@ -184,7 +184,7 @@ fn main() {
             } else if z == startzoomrangetoslice {
                 if 1 << (z * 2) > 1 {
                     targetrangetoslice = Some(starttargetrange..=(1 << (z * 2)) - 1);
-                }               
+                }
             } else if z == endzoomrangetoslice {
                 targetrangetoslice = Some(0..=endtargetrange);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 use image::{DynamicImage, ImageResult, SubImage};
-use std::ops::RangeInclusive;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::{ops::RangeInclusive, path::Path};
 use tile_split::{Config, Resizer, TileImage};
 
 fn save_subimage(
@@ -10,23 +10,20 @@ fn save_subimage(
     x: u32,
     y: u32,
     z: u8,
-    config: &Config,
+    folder: &Path,
+    tileformat: &str,
 ) -> ImageResult<()> {
-    img.to_image().save(config.folder.join(format!(
+    img.to_image().save(folder.join(format!(
         "{z}-{x}-{y}.{fmt}",
         z = z,
         x = x,
         y = y,
-        fmt = config.tileformat
+        fmt = tileformat
     )))
 }
 
-fn save_image(img: &DynamicImage, z: u8, config: &Config) -> ImageResult<()> {
-    img.save(
-        config
-            .folder
-            .join(format!("{z}.{fmt}", z = z, fmt = config.tileformat)),
-    )
+fn save_image(img: &DynamicImage, z: u8, folder: &Path, tileformat: &str) -> ImageResult<()> {
+    img.save(folder.join(format!("{z}.{fmt}", z = z, fmt = tileformat)))
 }
 
 fn parse_range<T>(arg: &str) -> Result<RangeInclusive<T>, <T as FromStr>::Err>
@@ -85,80 +82,19 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
-    let zomr = if args.zoomrange.is_empty() {
-        args.zoomlevel..=args.zoomlevel
-    } else {
-        args.zoomrange
-    };
-
     let save_resized = args.save_resize;
 
     // create output folder
     std::fs::create_dir_all(&args.output_dir).unwrap();
 
-    // total number of tiles required in zoomrange
-    let mut totaltiles = 0;
-    zomr.clone().for_each(|x| {
-        totaltiles += 1 << (x * 2);
-    });
-    let average = totaltiles / args.totalfunction;
-    // number of tiles sliced by previous functions
-    let tilessliced = average * (args.functionindex - 1);
-    // number of tiles to slice in this function, if it's the last
-    // function, it should slice all the remaining tiles
-    let mut tilestoslice = average;
-    if args.functionindex == args.totalfunction {
-        tilestoslice = totaltiles - tilessliced;
-    }
-
-    // zoom level to start
-    let mut startzoomrangetoslice: u8 = *zomr.clone().start();
-    // tile index to start
-    let mut starttargetrange: u32 = 0;
-    // zoom level to stop
-    let mut endzoomrangetoslice: u8 = *zomr.clone().end();
-    // tile index to stop
-    let mut endtargetrange: u32 = 0;
-
-    // total of tiles in previous zoom levels
-    let mut tilessum = 0;
-    // calculte startzoomrangetoslice and starttargetrange
-    for i in zomr.clone() {
-        // number of tiles in this zoom level
-        let currentzoomtiles = 1 << (i * 2);
-        if tilessum + currentzoomtiles > tilessliced {
-            startzoomrangetoslice = i;
-            starttargetrange = tilessliced - tilessum;
-            break;
-        } else {
-            tilessum += currentzoomtiles;
-        }
-    }
-    tilessum = 0;
-    // calculte endzoomrangetoslice and endtargetrange
-    for i in zomr.clone() {
-        // number of tiles in this zoom level
-        let currentzoomtiles = 1 << (i * 2);
-        if tilessum + currentzoomtiles >= tilessliced + tilestoslice {
-            endzoomrangetoslice = i;
-            endtargetrange = tilessliced + tilestoslice - tilessum - 1;
-            break;
-        } else {
-            tilessum += currentzoomtiles;
-        }
-    }
-
-    let config = Config {
-        tilesize: args.tilesize,
-        filename: &args.filename,
-        zoomlevel: args.zoomlevel,
-        zoomrange: zomr,
-        folder: &args.output_dir,
-        tileformat: &args.tileformat,
-        functionindex: args.functionindex,
-        totalfunction: args.totalfunction,
-        zoomrangetoslice: (startzoomrangetoslice..=endzoomrangetoslice),
-    };
+    let config = Config::new(
+        &args.filename,
+        args.tilesize,
+        args.zoomlevel,
+        args.zoomrange,
+        args.functionindex,
+        args.totalfunction,
+    );
 
     // instantiate TileImage
     let tile_image = TileImage { config: &config };
@@ -168,29 +104,32 @@ fn main() {
     let resized_images = config.resize_range(image);
 
     if save_resized {
-        resized_images.for_each(|(img, z)| save_image(&img, z, &config).unwrap())
+        resized_images
+            .for_each(|(img, z)| save_image(&img, z, &args.output_dir, &args.tileformat).unwrap())
     } else {
         // save each sliced image
         resized_images.for_each(|(img, z)| {
             let mut targetrangetoslice: Option<RangeInclusive<u32>> = None;
             // if startzoomrangetoslice is the same as endzoomrangetoslice,
             // then tiles to be sliced in this function are from same zoom level
-            if startzoomrangetoslice == endzoomrangetoslice {
-                if z == endzoomrangetoslice {
-                    targetrangetoslice = Some(starttargetrange..=endtargetrange);
+            if config.startzoomrangetoslice == config.endzoomrangetoslice {
+                if z == config.endzoomrangetoslice {
+                    targetrangetoslice = Some(config.starttargetrange..=config.endtargetrange);
                 }
             // otherwise, the start zoom level should slice tiles from starttargetrange to end,
             // the end zoom level should slice tiles from 0 to endtargetrange
-            } else if z == startzoomrangetoslice {
+            } else if z == config.startzoomrangetoslice {
                 if 1 << (z * 2) > 1 {
-                    targetrangetoslice = Some(starttargetrange..=(1 << (z * 2)) - 1);
+                    targetrangetoslice = Some(config.starttargetrange..=(1 << (z * 2)) - 1);
                 }
-            } else if z == endzoomrangetoslice {
-                targetrangetoslice = Some(0..=endtargetrange);
+            } else if z == config.endzoomrangetoslice {
+                targetrangetoslice = Some(0..=config.endtargetrange);
             }
             tile_image
                 .iter(&img, targetrangetoslice)
-                .for_each(|(sub_img, x, y)| save_subimage(&sub_img, x, y, z, &config).unwrap());
+                .for_each(|(sub_img, x, y)| {
+                    save_subimage(&sub_img, x, y, z, &args.output_dir, &args.tileformat).unwrap()
+                });
         });
     }
 }

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -24,7 +24,7 @@ fn args_file_only() {
 
 #[test]
 fn all_args() {
-    let args = parse(["bin", "-l", "7", "a-file.png", "-r", "0-5", "-t", "0-333"]);
+    let args = parse(["bin", "-l", "7", "a-file.png", "-r", "0-5",]);
     assert_eq!(args.filename.as_path().display().to_string(), "a-file.png");
     assert_eq!(args.zoomlevel, 7);
     assert_eq!(args.zoomrange, 0..=5);

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -24,8 +24,8 @@ fn args_file_only() {
 
 #[test]
 fn all_args() {
-    let args = parse(["bin", "-l", "7", "a-file.png", "-r", "0-5"]);
+    let args = parse(["bin", "-l", "7", "a-file.png", "-r", "0-5", "-t", "0-333"]);
     assert_eq!(args.filename.as_path().display().to_string(), "a-file.png");
     assert_eq!(args.zoomlevel, 7);
-    assert_eq!(args.zoomrange, 0..=5);
+    assert_eq!(args.targetrange, Some(0..=333));
 }

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -28,5 +28,4 @@ fn all_args() {
     assert_eq!(args.filename.as_path().display().to_string(), "a-file.png");
     assert_eq!(args.zoomlevel, 7);
     assert_eq!(args.zoomrange, 0..=5);
-    assert_eq!(args.targetrange, Some(0..=333));
 }

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -27,5 +27,6 @@ fn all_args() {
     let args = parse(["bin", "-l", "7", "a-file.png", "-r", "0-5", "-t", "0-333"]);
     assert_eq!(args.filename.as_path().display().to_string(), "a-file.png");
     assert_eq!(args.zoomlevel, 7);
+    assert_eq!(args.zoomrange, 0..=5);
     assert_eq!(args.targetrange, Some(0..=333));
 }

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -24,7 +24,7 @@ fn args_file_only() {
 
 #[test]
 fn all_args() {
-    let args = parse(["bin", "-l", "7", "a-file.png", "-r", "0-5",]);
+    let args = parse(["bin", "-l", "7", "a-file.png", "-r", "0-5"]);
     assert_eq!(args.filename.as_path().display().to_string(), "a-file.png");
     assert_eq!(args.zoomlevel, 7);
     assert_eq!(args.zoomrange, 0..=5);

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -11,7 +11,7 @@ pub trait Resizer<'iter, T> {
 type ResizedItem = (DynamicImage, u8);
 
 fn _check_dimension(config: &Config, img: &DynamicImage) {
-    if *config.zoomrangetoslice.end() > config.zoomlevel {
+    if config.endzoomrangetoslice > config.zoomlevel {
         panic!("Zoom range has value(s) larger than zoom level.");
     }
     let (img_width, img_height) = (img.width(), img.height());
@@ -38,9 +38,11 @@ impl<'iter> Resizer<'iter, DynamicImage> for Config<'_> {
     fn resize_range(&'iter self, img: &'iter DynamicImage) -> Self::ItemIterator {
         _check_dimension(self, img);
 
-        Box::new(self.zoomrangetoslice.clone().map(|x| {
-            let t_size = self.tilesize << x;
-            (_resize(img, t_size, t_size), x)
-        }))
+        Box::new(
+            (self.startzoomrangetoslice..self.endzoomrangetoslice).map(|x| {
+                let t_size = self.tilesize << x;
+                (_resize(img, t_size, t_size), x)
+            }),
+        )
     }
 }

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -1,3 +1,5 @@
+use std::ops::RangeInclusive;
+
 use crate::Config;
 use image::imageops;
 use image::DynamicImage;
@@ -39,7 +41,7 @@ impl<'iter> Resizer<'iter, DynamicImage> for Config<'_> {
         _check_dimension(self, img);
 
         Box::new(
-            (self.startzoomrangetoslice..self.endzoomrangetoslice).map(|x| {
+            RangeInclusive::new(self.startzoomrangetoslice, self.endzoomrangetoslice).map(|x| {
                 let t_size = self.tilesize << x;
                 (_resize(img, t_size, t_size), x)
             }),

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -11,7 +11,7 @@ pub trait Resizer<'iter, T> {
 type ResizedItem = (DynamicImage, u8);
 
 fn _check_dimension(config: &Config, img: &DynamicImage) {
-    if *config.zoomrange.end() > config.zoomlevel {
+    if *config.zoomrangetoslice.end() > config.zoomlevel {
         panic!("Zoom range has value(s) larger than zoom level.");
     }
     let (img_width, img_height) = (img.width(), img.height());
@@ -38,7 +38,7 @@ impl<'iter> Resizer<'iter, DynamicImage> for Config<'_> {
     fn resize_range(&'iter self, img: &'iter DynamicImage) -> Self::ItemIterator {
         _check_dimension(self, img);
 
-        Box::new(self.zoomrange.clone().map(|x| {
+        Box::new(self.zoomrangetoslice.clone().map(|x| {
             let t_size = self.tilesize << x;
             (_resize(img, t_size, t_size), x)
         }))


### PR DESCRIPTION
Based on suggestion in review from https://github.com/VisualMeaning/tile-split/pull/13, we want to make the code calculate the correct range of of tiles to slice.


https://visual-meaning.atlassian.net/browse/SMP-1999