### PR TITLE
Make --zoomrange optional

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -16,14 +16,10 @@ impl<'a> Config<'a> {
         filename: &'a Path,                       // $1
         tilesize: u32,                            // 256
         zoomlevel: u8,                            // eg 5
-        zoomrange: RangeInclusive<u8>,            // eg 0 - 5
+        zoomrange: Option<RangeInclusive<u8>>,    // eg 0 - 5
         targetrange: Option<RangeInclusive<u32>>, //eg 0 - 500
     ) -> Self {
-        let zomr = if zoomrange.is_empty() {
-            zoomlevel..=zoomlevel
-        } else {
-            zoomrange
-        };
+        let zomr = zoomrange.unwrap_or(zoomlevel..=zoomlevel);
         // total number of tiles required in zoomrange
         let mut totaltiles = 0;
         zomr.clone().for_each(|x| {
@@ -104,7 +100,7 @@ mod tests {
             &Path::new("test.png"),
             256,
             5,
-            RangeInclusive::new(0, 5),
+            Some(RangeInclusive::new(0, 5)),
             None,
         );
         assert_eq!(config.startzoomrangetoslice, 0);
@@ -120,7 +116,7 @@ mod tests {
             &Path::new("test.png"),
             256,
             5,
-            RangeInclusive::new(0, 5),
+            Some(RangeInclusive::new(0, 5)),
             Some(RangeInclusive::new(0, 341)),
         );
         assert_eq!(config.startzoomrangetoslice, 0);
@@ -136,7 +132,7 @@ mod tests {
             &Path::new("test.png"),
             256,
             5,
-            RangeInclusive::new(0, 5),
+            Some(RangeInclusive::new(0, 5)),
             Some(RangeInclusive::new(341, 682)),
         );
         assert_eq!(config.startzoomrangetoslice, 5);
@@ -152,7 +148,7 @@ mod tests {
             &Path::new("test.png"),
             256,
             5,
-            RangeInclusive::new(0, 5),
+            Some(RangeInclusive::new(0, 5)),
             Some(RangeInclusive::new(682, 1023)),
         );
         assert_eq!(config.startzoomrangetoslice, 5);
@@ -168,7 +164,7 @@ mod tests {
             &Path::new("test.png"),
             256,
             5,
-            RangeInclusive::new(0, 5),
+            Some(RangeInclusive::new(0, 5)),
             Some(RangeInclusive::new(1023, 1365)),
         );
         assert_eq!(config.startzoomrangetoslice, 5);
@@ -184,7 +180,7 @@ mod tests {
             &Path::new("test.png"),
             256,
             5,
-            RangeInclusive::new(3, 5),
+            Some(RangeInclusive::new(3, 5)),
             Some(RangeInclusive::new(0, 448)),
         );
         assert_eq!(config.startzoomrangetoslice, 3);
@@ -200,7 +196,7 @@ mod tests {
             &Path::new("test.png"),
             256,
             5,
-            RangeInclusive::new(3, 5),
+            Some(RangeInclusive::new(3, 5)),
             Some(RangeInclusive::new(448, 896)),
         );
         assert_eq!(config.startzoomrangetoslice, 5);
@@ -216,7 +212,7 @@ mod tests {
             &Path::new("test.png"),
             256,
             5,
-            RangeInclusive::new(3, 5),
+            Some(RangeInclusive::new(3, 5)),
             Some(RangeInclusive::new(896, 1344)),
         );
         assert_eq!(config.startzoomrangetoslice, 5);

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,13 +96,7 @@ mod tests {
     #[test]
     // build config with only required args
     fn minimum_args() {
-        let config = Config::new(
-            &Path::new("test.png"),
-            256,
-            5,
-            None,
-            None,
-        );
+        let config = Config::new(&Path::new("test.png"), 256, 5, None, None);
         assert_eq!(config.startzoomrangetoslice, 5);
         assert_eq!(config.starttargetrange, 0);
         assert_eq!(config.endzoomrangetoslice, 5);

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,22 @@ mod tests {
     use std::{ops::RangeInclusive, path::Path};
 
     #[test]
+    // build config with only required args
+    fn minimum_args() {
+        let config = Config::new(
+            &Path::new("test.png"),
+            256,
+            5,
+            None,
+            None,
+        );
+        assert_eq!(config.startzoomrangetoslice, 5);
+        assert_eq!(config.starttargetrange, 0);
+        assert_eq!(config.endzoomrangetoslice, 5);
+        assert_eq!(config.endtargetrange, 1023);
+    }
+
+    #[test]
     // slice all tiles
     fn full_zoom() {
         let config = Config::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ struct Args {
 
     /// Zoomrange to slice tiles for.
     #[arg(short='r', long, required(false), value_parser = parse_range::<u8>)]
-    zoomrange: RangeInclusive<u8>,
+    zoomrange: Option<RangeInclusive<u8>>,
 
     /// Location to write output tiles to.
     #[arg(short, long, env, required(false), default_value("out"))]

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -27,6 +27,6 @@ fn all_args() {
     let args = parse(["bin", "-l", "7", "a-file.png", "-r", "0-5", "-t", "0-333"]);
     assert_eq!(args.filename.as_path().display().to_string(), "a-file.png");
     assert_eq!(args.zoomlevel, 7);
-    assert_eq!(args.zoomrange, 0..=5);
+    assert_eq!(args.zoomrange, Some(0..=5));
     assert_eq!(args.targetrange, Some(0..=333));
 }


### PR DESCRIPTION
Fixes [SMP-2044](https://visual-meaning.atlassian.net/browse/SMP-2044)

A slightly confusing error symptom (passing no args says that --zoomlevel is required but not --zoomrange, passing --zoomlevel then claims that --zoomrange is required) that turned out to be because of erroneous typing: since `zoomrange` is a `RangeInclusive` it's always expected to exist and bad things happen if it does not.

Change it to an `Option<RangeInclusive>` along with associated test fixes.

[SMP-2044]: https://visual-meaning.atlassian.net/browse/SMP-2044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ