### PR TITLE
Support slicing sub image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+.vscode/launch.json
 
 # Outputs
 /out

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ For example, for a chunk size of 300 tiles per round, the arguments would be
 
 Note that we cannot upscale an input PNG to higher zoomlevels, only downscale -- so all zoomlevels passed via `--zoomrange` must be equal to or less than the input PNG zoomlevel passed via `--zoomlevel`.
 
+If `--parentzoomlevel` is provided, it indicates that the input PNG has the dimension of the `--zoomlevel` value and is sliced from an whole png of dimension `--parentzoomlevel`. `--indexforzoom` indicates the index of the input PNG among all the sliced ones (Note the index needs to follow Z-curve). If `--parentzoomlevel` is provided, `--zoomrange` and `--targetrange` will be ignored and the code will split the input PNG to all tiles and give it the correct names that corresponds to the parent zoom level location. These arguments are designed to be run by multiple lambda function to slice level 6 and level 7 PNGs.
+
+For example, if we have four level 5 dimension PNGs sliced from one whole level 6 PNG, by running
+
+    tile-split 5-0-0.png --zoomlevel 5 --parentzoomlevel 6 --indexforzoom 0
+    tile-split 5-1-0.png --zoomlevel 5 --parentzoomlevel 6 --indexforzoom 1
+    tile-split 5-0-1.png --zoomlevel 5 --parentzoomlevel 6 --indexforzoom 2
+    tile-split 5-1-1.png --zoomlevel 5 --parentzoomlevel 6 --indexforzoom 3
+This will output all 4096 tiles from level 6 with correct names.
+
 Run `tile-split --help` for more command description.
 
 ```
@@ -49,15 +59,30 @@ Arguments:
   <FILENAME>  Input PNG filename
 
 Options:
-  -l, --zoomlevel <ZOOMLEVEL>     Zoomlevel of input PNG file [env: ZOOMLEVEL=]
-  -r, --zoomrange <ZOOMRANGE>...  Zoomrange to slice tiles for
-  -t, --targetrange               Targetrange to slice subset of tiles. Optional.
-  -o, --output-dir <OUTPUT_DIR>   Location to write output tiles to [env: OUTPUT_DIR=] [default: out]
-  -s, --tilesize <TILESIZE>       Dimension of output tiles, in pixels [default: 256]
-  -f, --tileformat <TILEFORMAT>   Type of output tiles, currently unused [env: TILEFORMAT=] [default: png]
-      --save-resize               Save the resized files [env: SAVE_RESIZE=]
-  -h, --help                      Print help
-  -V, --version                   Print version
+  -l, --zoomlevel <ZOOMLEVEL>
+          Zoomlevel of input PNG file [env: ZOOMLEVEL=]
+  -p, --parentzoomlevel <PARENTZOOMLEVEL>
+          Parent zoomlevel of input sub PNG file
+  -i, --indexforzoom <INDEXFORZOOM>
+          Index of the input sub PNG [default: 0]
+  -r, --zoomrange <ZOOMRANGE>
+          Zoomrange to slice tiles for
+  -o, --output-dir <OUTPUT_DIR>
+          Location to write output tiles to [env: OUTPUT_DIR=] [default: out]
+      --tilesize <TILESIZE>
+          Dimension of output tiles, in pixels [default: 256]
+      --tileformat <TILEFORMAT>
+          Type of output tiles [env: TILEFORMAT=] [default: png]
+  -t, --targetrange <TARGETRANGE>
+          Subset morton range of tiles to slice
+      --preset <PRESET>
+          PNG compression preset [env: PRESET=]
+      --save-resize
+          Save the resized files [env: SAVE_RESIZE=]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,7 +41,7 @@ impl Config {
             // total number of tiles required in zoomrange
             let mut totaltiles = 0;
             zomr.clone().for_each(|x| {
-                totaltiles += 1 << (x * 2);
+                totaltiles += (1 << (x * 2)) * 256 * 256 / tilesize.pow(2);
             });
             // number of tiles sliced
             let tilessliced = match &targetrange {
@@ -71,7 +71,7 @@ impl Config {
             // calculte startzoomrangetoslice and starttargetrange
             for i in zomr.clone() {
                 // number of tiles in this zoom level
-                let currentzoomtiles = 1 << (i * 2);
+                let currentzoomtiles = (1 << (i * 2)) * 256 * 256 / tilesize.pow(2);
                 if tilessum + currentzoomtiles > tilessliced {
                     startzoomrangetoslice = i;
                     starttargetrange = tilessliced - tilessum;
@@ -84,7 +84,7 @@ impl Config {
             // calculte endzoomrangetoslice and endtargetrange
             for i in zomr.clone() {
                 // number of tiles in this zoom level
-                let currentzoomtiles = 1 << (i * 2);
+                let currentzoomtiles = (1 << (i * 2)) * 256 * 256 / tilesize.pow(2);
                 if tilessum + currentzoomtiles >= tilessliced + tilestoslice {
                     endzoomrangetoslice = i;
                     endtargetrange = tilessliced + tilestoslice - tilessum - 1;
@@ -261,5 +261,21 @@ mod tests {
         );
         assert_eq!(config.zoomrangetoslice, 5..=5);
         assert_eq!(config.targetrangetoslice, 576..=1023);
+    }
+
+    #[test]
+    // slice level 6 tiles to 4 level 5 tiles
+    fn tilesize_level_5() {
+        let config = Config::new(
+            8192,
+            6,
+            None,
+            0,
+            Some(RangeInclusive::new(6, 6)),
+            None,
+            Some(2),
+        );
+        assert_eq!(config.zoomrangetoslice, 6..=6);
+        assert_eq!(config.targetrangetoslice, 0..=3);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,15 +26,21 @@ impl Config {
         targetrange: Option<RangeInclusive<u32>>, //eg 0 - 500
         preset: Option<u8>,
     ) -> Self {
-        if parentzoomlevel.is_some() && parentzoomlevel.unwrap() > zoomlevel {
-            Config {
-                tilesize,
-                zoomlevel,
-                parentzoomlevel,
-                indexforzoom,
-                preset,
-                zoomrangetoslice: 5..=5,
-                targetrangetoslice: 0..=1023,
+        if parentzoomlevel.is_some() {
+            if parentzoomlevel.unwrap() > zoomlevel {
+                Config {
+                    tilesize,
+                    zoomlevel,
+                    parentzoomlevel,
+                    indexforzoom,
+                    preset,
+                    zoomrangetoslice: zoomlevel..=zoomlevel,
+                    targetrangetoslice: 0..=(1 << (zoomlevel * 2)) - 1,
+                }
+            } else {
+                panic!(
+                    "Parent zoom level number needs to be bigger than the input image zoom level."
+                )
             }
         } else {
             let zomr = zoomrange.unwrap_or(zoomlevel..=zoomlevel);
@@ -261,5 +267,13 @@ mod tests {
         );
         assert_eq!(config.zoomrangetoslice, 5..=5);
         assert_eq!(config.targetrangetoslice, 576..=1023);
+    }
+
+    #[test]
+    // slice the third level 5 sub image of a level 6 image
+    fn sub_image_1() {
+        let config = Config::new(256, 5, Some(6), 2, None, None, Some(2));
+        assert_eq!(config.zoomrangetoslice, 5..=5);
+        assert_eq!(config.targetrangetoslice, 0..=1023);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,8 +271,16 @@ mod tests {
 
     #[test]
     // slice the third level 5 sub image of a level 6 image
-    fn sub_image_1() {
+    fn sub_image_level_6() {
         let config = Config::new(256, 5, Some(6), 2, None, None, Some(2));
+        assert_eq!(config.zoomrangetoslice, 5..=5);
+        assert_eq!(config.targetrangetoslice, 0..=1023);
+    }
+
+    #[test]
+    // slice the 15th level 5 sub image of a level 7 image
+    fn sub_image_level_7() {
+        let config = Config::new(256, 5, Some(7), 15, None, None, Some(2));
         assert_eq!(config.zoomrangetoslice, 5..=5);
         assert_eq!(config.targetrangetoslice, 0..=1023);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,8 @@ use crate::TileImage;
 pub struct Config {
     pub tilesize: u32, // 256
     pub zoomlevel: u8, // eg 5
+    pub parentzoomlevel: Option<u8>,
+    pub indexforzoom: u8,
     pub preset: Option<u8>,
     pub startzoomrangetoslice: u8,
     pub endzoomrangetoslice: u8,
@@ -18,77 +20,94 @@ pub struct Config {
 impl Config {
     pub fn new(
         // $1
-        tilesize: u32,                            // 256
-        zoomlevel: u8,                            // eg 5
+        tilesize: u32, // 256
+        zoomlevel: u8, // eg 5
+        parentzoomlevel: Option<u8>,
+        indexforzoom: u8,                         // eg 1
         zoomrange: Option<RangeInclusive<u8>>,    // eg 0 - 5
         targetrange: Option<RangeInclusive<u32>>, //eg 0 - 500
         preset: Option<u8>,
     ) -> Self {
-        let zomr = zoomrange.unwrap_or(zoomlevel..=zoomlevel);
-        // total number of tiles required in zoomrange
-        let mut totaltiles = 0;
-        zomr.clone().for_each(|x| {
-            totaltiles += 1 << (x * 2);
-        });
-        // number of tiles sliced
-        let tilessliced = match &targetrange {
-            Some(targetrange) => *targetrange.start(),
-            None => 0,
-        };
-        // number of tiles to slice
-        let tilestoslice = match &targetrange {
-            Some(targetrange) => *targetrange.end() - tilessliced,
-            None => totaltiles,
-        };
-        if tilestoslice > totaltiles {
-            panic!("Target range value cannot be over than the total number of tiles within zoom range.");
-        }
-
-        // zoom level to start
-        let mut startzoomrangetoslice: u8 = *zomr.clone().start();
-        // tile index to start
-        let mut starttargetrange: u32 = 0;
-        // zoom level to stop
-        let mut endzoomrangetoslice: u8 = *zomr.clone().end();
-        // tile index to stop
-        let mut endtargetrange: u32 = 0;
-
-        // total of tiles in previous zoom levels
-        let mut tilessum = 0;
-        // calculte startzoomrangetoslice and starttargetrange
-        for i in zomr.clone() {
-            // number of tiles in this zoom level
-            let currentzoomtiles = 1 << (i * 2);
-            if tilessum + currentzoomtiles > tilessliced {
-                startzoomrangetoslice = i;
-                starttargetrange = tilessliced - tilessum;
-                break;
-            } else {
-                tilessum += currentzoomtiles;
+        if parentzoomlevel.is_some() && parentzoomlevel.unwrap() > zoomlevel {
+            Config {
+                tilesize,
+                zoomlevel,
+                parentzoomlevel,
+                indexforzoom,
+                preset,
+                startzoomrangetoslice: 5,
+                endzoomrangetoslice: 5,
+                starttargetrange: 0,
+                endtargetrange: 1023,
             }
-        }
-        tilessum = 0;
-        // calculte endzoomrangetoslice and endtargetrange
-        for i in zomr.clone() {
-            // number of tiles in this zoom level
-            let currentzoomtiles = 1 << (i * 2);
-            if tilessum + currentzoomtiles >= tilessliced + tilestoslice {
-                endzoomrangetoslice = i;
-                endtargetrange = tilessliced + tilestoslice - tilessum - 1;
-                break;
-            } else {
-                tilessum += currentzoomtiles;
+        } else {
+            let zomr = zoomrange.unwrap_or(zoomlevel..=zoomlevel);
+            // total number of tiles required in zoomrange
+            let mut totaltiles = 0;
+            zomr.clone().for_each(|x| {
+                totaltiles += 1 << (x * 2);
+            });
+            // number of tiles sliced
+            let tilessliced = match &targetrange {
+                Some(targetrange) => *targetrange.start(),
+                None => 0,
+            };
+            // number of tiles to slice
+            let tilestoslice = match &targetrange {
+                Some(targetrange) => *targetrange.end() - tilessliced,
+                None => totaltiles,
+            };
+            if tilestoslice > totaltiles {
+                panic!("Target range value cannot be over than the total number of tiles within zoom range.");
             }
-        }
 
-        Config {
-            tilesize,
-            zoomlevel,
-            preset,
-            startzoomrangetoslice,
-            endzoomrangetoslice,
-            starttargetrange,
-            endtargetrange,
+            // zoom level to start
+            let mut startzoomrangetoslice: u8 = *zomr.clone().start();
+            // tile index to start
+            let mut starttargetrange: u32 = 0;
+            // zoom level to stop
+            let mut endzoomrangetoslice: u8 = *zomr.clone().end();
+            // tile index to stop
+            let mut endtargetrange: u32 = 0;
+
+            // total of tiles in previous zoom levels
+            let mut tilessum = 0;
+            // calculte startzoomrangetoslice and starttargetrange
+            for i in zomr.clone() {
+                // number of tiles in this zoom level
+                let currentzoomtiles = 1 << (i * 2);
+                if tilessum + currentzoomtiles > tilessliced {
+                    startzoomrangetoslice = i;
+                    starttargetrange = tilessliced - tilessum;
+                    break;
+                } else {
+                    tilessum += currentzoomtiles;
+                }
+            }
+            tilessum = 0;
+            // calculte endzoomrangetoslice and endtargetrange
+            for i in zomr.clone() {
+                // number of tiles in this zoom level
+                let currentzoomtiles = 1 << (i * 2);
+                if tilessum + currentzoomtiles >= tilessliced + tilestoslice {
+                    endzoomrangetoslice = i;
+                    endtargetrange = tilessliced + tilestoslice - tilessum - 1;
+                    break;
+                } else {
+                    tilessum += currentzoomtiles;
+                }
+            }
+            Config {
+                tilesize,
+                zoomlevel,
+                parentzoomlevel,
+                indexforzoom,
+                preset,
+                startzoomrangetoslice,
+                endzoomrangetoslice,
+                starttargetrange,
+                endtargetrange,
+            }
         }
     }
 
@@ -115,7 +134,7 @@ mod tests {
     #[test]
     // build config with only required args
     fn minimum_args() {
-        let config = Config::new(256, 5, None, None, None);
+        let config = Config::new(256, 5, None, 0, None, None, None);
         assert_eq!(config.startzoomrangetoslice, 5);
         assert_eq!(config.starttargetrange, 0);
         assert_eq!(config.endzoomrangetoslice, 5);
@@ -126,7 +145,15 @@ mod tests {
     #[test]
     // slice all tiles
     fn full_zoom() {
-        let config = Config::new(256, 5, Some(RangeInclusive::new(0, 5)), None, Some(2));
+        let config = Config::new(
+            256,
+            5,
+            None,
+            0,
+            Some(RangeInclusive::new(0, 5)),
+            None,
+            Some(2),
+        );
         assert_eq!(config.startzoomrangetoslice, 0);
         assert_eq!(config.starttargetrange, 0);
         assert_eq!(config.endzoomrangetoslice, 5);
@@ -140,6 +167,8 @@ mod tests {
         let config = Config::new(
             256,
             5,
+            None,
+            0,
             Some(RangeInclusive::new(0, 5)),
             Some(RangeInclusive::new(0, 341)),
             Some(2),
@@ -156,6 +185,8 @@ mod tests {
         let config = Config::new(
             256,
             5,
+            None,
+            0,
             Some(RangeInclusive::new(0, 5)),
             Some(RangeInclusive::new(341, 682)),
             Some(2),
@@ -172,6 +203,8 @@ mod tests {
         let config = Config::new(
             256,
             5,
+            None,
+            0,
             Some(RangeInclusive::new(0, 5)),
             Some(RangeInclusive::new(682, 1023)),
             Some(2),
@@ -188,6 +221,8 @@ mod tests {
         let config = Config::new(
             256,
             5,
+            None,
+            0,
             Some(RangeInclusive::new(0, 5)),
             Some(RangeInclusive::new(1023, 1365)),
             Some(2),
@@ -204,6 +239,8 @@ mod tests {
         let config = Config::new(
             256,
             5,
+            None,
+            0,
             Some(RangeInclusive::new(3, 5)),
             Some(RangeInclusive::new(0, 448)),
             Some(2),
@@ -220,6 +257,8 @@ mod tests {
         let config = Config::new(
             256,
             5,
+            None,
+            0,
             Some(RangeInclusive::new(3, 5)),
             Some(RangeInclusive::new(448, 896)),
             Some(2),
@@ -236,6 +275,8 @@ mod tests {
         let config = Config::new(
             256,
             5,
+            None,
+            0,
             Some(RangeInclusive::new(3, 5)),
             Some(RangeInclusive::new(896, 1344)),
             Some(2),

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,8 +26,8 @@ impl Config {
         targetrange: Option<RangeInclusive<u32>>, //eg 0 - 500
         preset: Option<u8>,
     ) -> Self {
-        if parentzoomlevel.is_some() {
-            if parentzoomlevel.unwrap() > zoomlevel {
+        if let Some(parentzoomlevelvalue) = parentzoomlevel {
+            if parentzoomlevelvalue > zoomlevel {
                 Config {
                     tilesize,
                     zoomlevel,

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,20 +27,22 @@ impl Config {
         preset: Option<u8>,
     ) -> Self {
         if let Some(parentzoomlevelvalue) = parentzoomlevel {
-            if parentzoomlevelvalue > zoomlevel {
-                Config {
-                    tilesize,
-                    zoomlevel,
-                    parentzoomlevel,
-                    indexforzoom,
-                    preset,
-                    zoomrangetoslice: zoomlevel..=zoomlevel,
-                    targetrangetoslice: 0..=(1 << (zoomlevel * 2)) - 1,
-                }
-            } else {
+            if parentzoomlevelvalue <= zoomlevel {
                 panic!(
                     "Parent zoom level number needs to be bigger than the input image zoom level."
                 )
+            }
+            if indexforzoom > (1 << ((parentzoomlevelvalue - zoomlevel) * 2)) - 1 {
+                panic!("indexforzoom value is larger than allowed.")
+            }
+            Config {
+                tilesize,
+                zoomlevel,
+                parentzoomlevel,
+                indexforzoom,
+                preset,
+                zoomrangetoslice: zoomlevel..=zoomlevel,
+                targetrangetoslice: 0..=(1 << (zoomlevel * 2)) - 1,
             }
         } else {
             let zomr = zoomrange.unwrap_or(zoomlevel..=zoomlevel);
@@ -283,5 +285,26 @@ mod tests {
         let config = Config::new(256, 5, Some(7), 15, None, None, Some(2));
         assert_eq!(config.zoomrangetoslice, 5..=5);
         assert_eq!(config.targetrangetoslice, 0..=1023);
+    }
+
+    #[test]
+    #[should_panic]
+    // should panic if zoomlevel is larger than parentzoomlevel
+    fn sub_image_zoom_largerthan_parent() {
+        Config::new(256, 5, Some(4), 15, None, None, Some(2));
+    }
+
+    #[test]
+    #[should_panic]
+    // should panic if indexforzoom is larger than allowed
+    fn sub_image_wrong_indexforzoom_1() {
+        Config::new(256, 5, Some(6), 4, None, None, Some(2));
+    }
+
+    #[test]
+    #[should_panic]
+    // should panic if indexforzoom is larger than allowed
+    fn sub_image_wrong_indexforzoom_2() {
+        Config::new(256, 5, Some(7), 16, None, None, Some(2));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,7 +41,7 @@ impl Config {
             // total number of tiles required in zoomrange
             let mut totaltiles = 0;
             zomr.clone().for_each(|x| {
-                totaltiles += (1 << (x * 2)) * 256 * 256 / tilesize.pow(2);
+                totaltiles += 1 << (x * 2);
             });
             // number of tiles sliced
             let tilessliced = match &targetrange {
@@ -71,7 +71,7 @@ impl Config {
             // calculte startzoomrangetoslice and starttargetrange
             for i in zomr.clone() {
                 // number of tiles in this zoom level
-                let currentzoomtiles = (1 << (i * 2)) * 256 * 256 / tilesize.pow(2);
+                let currentzoomtiles = 1 << (i * 2);
                 if tilessum + currentzoomtiles > tilessliced {
                     startzoomrangetoslice = i;
                     starttargetrange = tilessliced - tilessum;
@@ -84,7 +84,7 @@ impl Config {
             // calculte endzoomrangetoslice and endtargetrange
             for i in zomr.clone() {
                 // number of tiles in this zoom level
-                let currentzoomtiles = (1 << (i * 2)) * 256 * 256 / tilesize.pow(2);
+                let currentzoomtiles = 1 << (i * 2);
                 if tilessum + currentzoomtiles >= tilessliced + tilestoslice {
                     endzoomrangetoslice = i;
                     endtargetrange = tilessliced + tilestoslice - tilessum - 1;
@@ -261,21 +261,5 @@ mod tests {
         );
         assert_eq!(config.zoomrangetoslice, 5..=5);
         assert_eq!(config.targetrangetoslice, 576..=1023);
-    }
-
-    #[test]
-    // slice level 6 tiles to 4 level 5 tiles
-    fn tilesize_level_5() {
-        let config = Config::new(
-            8192,
-            6,
-            None,
-            0,
-            Some(RangeInclusive::new(6, 6)),
-            None,
-            Some(2),
-        );
-        assert_eq!(config.zoomrangetoslice, 6..=6);
-        assert_eq!(config.targetrangetoslice, 0..=3);
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -38,18 +38,20 @@ impl<'c> TileImage<'c> {
         let mut targetrangetoslice = 0..=morton_idx_max - 1;
         // if startzoomrangetoslice is the same as endzoomrangetoslice,
         // then tiles to be sliced in this function are from same zoom level
-        if self.config.startzoomrangetoslice == self.config.endzoomrangetoslice {
-            if index == self.config.endzoomrangetoslice {
-                targetrangetoslice = self.config.starttargetrange..=self.config.endtargetrange;
+        if self.config.zoomrangetoslice.start() == self.config.zoomrangetoslice.end() {
+            if index == *self.config.zoomrangetoslice.end() {
+                targetrangetoslice =
+                    *self.config.targetrangetoslice.start()..=*self.config.targetrangetoslice.end();
             }
         // otherwise, the start zoom level should slice tiles from starttargetrange to end,
         // the end zoom level should slice tiles from 0 to endtargetrange
-        } else if index == self.config.startzoomrangetoslice {
+        } else if index == *self.config.zoomrangetoslice.start() {
             if index > 0 {
-                targetrangetoslice = self.config.starttargetrange..=(1 << (index * 2)) - 1;
+                targetrangetoslice =
+                    *self.config.targetrangetoslice.start()..=(1 << (index * 2)) - 1;
             }
-        } else if index == self.config.endzoomrangetoslice {
-            targetrangetoslice = 0..=self.config.endtargetrange;
+        } else if index == *self.config.zoomrangetoslice.end() {
+            targetrangetoslice = 0..=*self.config.targetrangetoslice.end();
         }
 
         targetrangetoslice
@@ -70,26 +72,6 @@ impl<'c> TileImage<'c> {
                 }
             })
             .collect()
-    }
-
-    fn _check_dimension(&self) {
-        // TODO: work with any dimension (albeit square image),
-        // resize to proper zoom size then split into tiles of config.tilesize side.
-        if self.config.endzoomrangetoslice > self.config.zoomlevel {
-            panic!("Zoom range has value(s) larger than zoom level.");
-        }
-        let (img_width, img_height) = (self.img.width(), self.img.height());
-        let max_dimension_size = self.config.tilesize << self.config.zoomlevel;
-        if img_width != max_dimension_size || img_height != max_dimension_size {
-            panic!(
-                "Image of size {w}x{h} cannot be split into
-                tiles of size {tile_size} and max zoom level {max_zoom}.",
-                w = img_width,
-                h = img_height,
-                tile_size = self.config.tilesize,
-                max_zoom = self.config.zoomlevel,
-            );
-        }
     }
 
     pub fn save_image(&self, z: u8, folder: &Path, tileformat: &str) -> ImageResult<()> {

--- a/src/image.rs
+++ b/src/image.rs
@@ -60,8 +60,8 @@ impl<'c> TileImage<'c> {
                 let tilename = format!(
                     "{z}-{x}-{y}",
                     z = output_level,
-                    x = (coord.0 * tileimage_coord.0) as u32,
-                    y = (coord.1 * tileimage_coord.1) as u32
+                    x = (coord.0 + (tileimage_coord.0 * 32)) as u32,
+                    y = (coord.1 + (tileimage_coord.1 * 32)) as u32
                 );
                 Tile {
                     config: self.config,

--- a/src/image.rs
+++ b/src/image.rs
@@ -15,12 +15,12 @@ impl<'c> TileImage<'c> {
         let height_in_tiles = self.img.height() / self.config.tilesize;
         let morton_idx_max = width_in_tiles * height_in_tiles;
         let tileimage_coord: (u16, u16) = match &self.config.parentzoomlevel {
-            None => (1, 1),
+            None => (0, 0),
             Some(parentzoomlevel) => {
                 if parentzoomlevel > &self.config.zoomlevel {
                     coord_of(self.config.indexforzoom.into())
                 } else {
-                    (1, 1)
+                    (0, 0)
                 }
             }
         };

--- a/src/image.rs
+++ b/src/image.rs
@@ -11,9 +11,8 @@ pub struct TileImage<'c> {
 
 impl<'c> TileImage<'c> {
     pub fn slice_tiles(&self, index: u8) -> Vec<Tile> {
-        let width_in_tiles = self.img.width() / self.config.tilesize;
-        let height_in_tiles = self.img.height() / self.config.tilesize;
-        let morton_idx_max = width_in_tiles * height_in_tiles;
+        let tiles_per_row = 1 << index;
+        let morton_idx_max = tiles_per_row * tiles_per_row;
         let tileimage_coord: (u16, u16) = match &self.config.parentzoomlevel {
             None => (0, 0),
             Some(parentzoomlevel) => {
@@ -60,8 +59,8 @@ impl<'c> TileImage<'c> {
                 let tilename = format!(
                     "{z}-{x}-{y}",
                     z = output_level,
-                    x = (coord.0 + (tileimage_coord.0 * 32)) as u32,
-                    y = (coord.1 + (tileimage_coord.1 * 32)) as u32
+                    x = (coord.0 + (tileimage_coord.0 * tiles_per_row as u16)) as u32,
+                    y = (coord.1 + (tileimage_coord.1 * tiles_per_row as u16)) as u32
                 );
                 Tile {
                     config: self.config,

--- a/src/image.rs
+++ b/src/image.rs
@@ -28,7 +28,7 @@ impl<'c> TileImage<'c> {
             None => index,
             Some(parentzoomlevel) => {
                 if parentzoomlevel > &self.config.zoomlevel {
-                    parentzoomlevel.clone()
+                    *parentzoomlevel
                 } else {
                     index
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,14 @@ struct Args {
     #[arg(short = 'l', long, env)]
     zoomlevel: u8,
 
+    /// Parent zoomlevel of input sub PNG file.
+    #[arg(short = 'p', long, required(false))]
+    parentzoomlevel: Option<u8>,
+
+    /// Index of the input sub PNG.
+    #[arg(short = 'i', long, required(false), default_value("0"))]
+    indexforzoom: u8,
+
     /// Zoomrange to slice tiles for.
     #[arg(short='r', long, required(false), value_parser = parse_range::<u8>)]
     zoomrange: Option<RangeInclusive<u8>>,
@@ -78,6 +86,8 @@ fn main() {
     let config = Config::new(
         args.tilesize,
         args.zoomlevel,
+        args.parentzoomlevel,
+        args.indexforzoom,
         args.zoomrange,
         args.targetrange,
         args.preset,
@@ -117,20 +127,15 @@ fn main() {
                 let img = tile.to_subimage();
                 if &args.tileformat == "png" {
                     let oxipng = tile.convert_to_oxipng(img);
-                    let path = &args.output_dir.join(format!(
-                        "{z}-{x}-{y}.png",
-                        z = z,
-                        x = tile.x,
-                        y = tile.y
-                    ));
+                    let path = &args
+                        .output_dir
+                        .join(format!("{name}.png", name = tile.name));
                     let mut file = File::create(path).unwrap();
                     file.write_all(&oxipng).unwrap();
                 } else {
                     let path = &args.output_dir.join(format!(
-                        "{z}-{x}-{y}.{fmt}",
-                        z = z,
-                        x = tile.x,
-                        y = tile.y,
+                        "{name}.{fmt}",
+                        name = tile.name,
                         fmt = &args.tileformat
                     ));
                     img.to_image().save(path).unwrap();


### PR DESCRIPTION
- Add argument `--parentzoomlevel` and `--indexforzoom`. If a valid `parentzoomlevel` value is provided, `zoomrange` and `targetrange` values will be ignored, it will slice all the tiles for the current `zoomlevel` value.  For example, for the four level 5 sub images from one level 5 image, `--zoomlevel` should be 5, `--parentzoomlevel` should be 6, and `--indexforzoom` should be a number in 0-3. It will slice 1024 tiles for each input image and give them appropriate naming. Running all four of them should output the same results as slicing all the tiles for one level 6 input image.
- Replace `startzoomrangetoslice` and `endzoomrangetoslice` to be `zoomrangetoslice`, `starttargetrange` and `endtargetrange` to be `targetrangetoslice` in config to clean up.


https://visual-meaning.atlassian.net/browse/SMP-2392